### PR TITLE
Improve `id_search()` name-matching

### DIFF
--- a/klee/members.py
+++ b/klee/members.py
@@ -1,7 +1,6 @@
 from .member_list import name_id, id_name
-from typing import Union
 import discord
-from discord.ext import commands
+import re
 
 def get_name(member_id):
     return id_name[member_id]
@@ -9,20 +8,32 @@ def get_name(member_id):
 def id_list():
     return _cached_id_list_sorted_by_name
 
-def id_search(ctx: Union[commands.Context, discord.Message], name_part: str):
+def id_search(message: discord.Message):
     member_id = 0
-    name_part_lower = name_part.lower()
-    if (name_part_lower == 'me') or ('me' in name_part_lower):
-        member_id = str(ctx.author.id)
+    # '@ultra @user1'
+    if len(message.raw_mentions) != 0:
+        member_id = str(message.raw_mentions[0])
     else:
-        if name_part_lower == 'dan':
-            member_id = str(name_id['Dan'])
-        elif name_part_lower == 'moon':
-            member_id = str(name_id['Moon'])
-        else:
-            for name in name_id:
-                if name_part_lower in name.lower():
-                    member_id = str(name_id[name])
+        normalized_separators = re.sub('[\s;,]+', ' ', message.content)
+        without_at_prefix = re.sub('(^| )@', ' ', normalized_separators)
+        normalized_message = re.sub('[^ a-zA-Z0-9][^ ]*', '', without_at_prefix)
+        words = normalized_message.split()
+        if len(words) > 0:
+            name_part = words[0]
+            name_part_lower = name_part.lower()
+            # '@ultra me'
+            if name_part_lower == 'me':
+                member_id = str(message.author.id)
+            # '@ultra user1'
+            else:
+                if name_part_lower == 'dan':
+                    member_id = str(name_id['Dan'])
+                elif name_part_lower == 'moon':
+                    member_id = str(name_id['Moon'])
+                else:
+                    for name in name_id:
+                        if name_part_lower in name.lower():
+                            member_id = str(name_id[name])
     return member_id
 
 def _id_list_sorted_by_name():

--- a/main.py
+++ b/main.py
@@ -201,18 +201,7 @@ async def message(message):
         #@ultra or @altra
         if is_any_word_in_string(const.PING_MENTIONS, message.content):
 
-            member_id = 0
-
-            #if the message is '@ultra @user'
-            if len(message.raw_mentions) != 0:
-                member_id = str(message.raw_mentions[0])
-
-            #if the message is '@ultra me', or '@ultra user'
-            else:
-                words = message.content.split()
-                if len(words) > 1:
-                    second_word = words[1]
-                    member_id = members.id_search(message, second_word)
+            member_id = members.id_search(message)
 
             reply_msg = ''
             if member_id == 0:
@@ -245,7 +234,7 @@ async def message(message):
 async def doubleping(ctx, *, member):
   try:
     if ctx.channel.id in const.BOT_CHANNELS:
-      member_id = members.id_search(ctx, member)
+      member_id = members.id_search(ctx.message)
 
       if member_id == 0:
         await ctx.send('Uh, Klee does not know this name, and therefore cannot subtract this slime from anyone... (๑•̆ ૩•̆)')
@@ -404,12 +393,11 @@ async def daily(ctx):
 
 #wrapper for add_slime method
 @client.command()
-async def add(ctx, number, *, username):
+async def add(ctx, number, *, member):
   try:
     if ctx.channel.id in const.BOT_CHANNELS:
-      log(f'[add] {ctx.message.author.display_name}: {number} {username}')
-      member = username.strip()
-      member_id = members.id_search(ctx, member)
+      log(f'[add] {ctx.message.author.display_name}: {number} {member}')
+      member_id = members.id_search(ctx.message)
 
       if member_id == 0:
         await ctx.send('Uh, Klee does not know this name, and therefore cannot add this slime from anyone... (๑•̆ ૩•̆)')
@@ -440,7 +428,7 @@ async def zoom(ctx, *, member):
   try:
     if ctx.channel.id in const.BOT_CHANNELS:
 
-      member_id = members.id_search(ctx, member)
+      member_id = members.id_search(ctx.message)
 
       if member_id == 0:
         await ctx.send ('Uh, Klee does not know this name, and therefore cannot subtract this slime from anyone...')
@@ -480,7 +468,7 @@ async def zoomc(ctx, *, member):
 #return the number of times the player have zoomed this season
   try:
     if ctx.channel.id in const.BOT_CHANNELS:
-      member_id = members.id_search(ctx, member)
+      member_id = members.id_search(ctx.message)
       member_idz = member_id +'z'
 
       #if the player has not zoomed yet
@@ -502,7 +490,7 @@ async def zoomt(ctx, *, member):
 #return the specific times the player was reported zooming
   try:
     if ctx.channel.id in const.BOT_CHANNELS:
-      member_id = members.id_search(ctx, member)
+      member_id = members.id_search(ctx.message)
       member_idzt = member_id +'zt'
 
       #if the player has not zoomed yet


### PR DESCRIPTION
Change `id_search()` name-matching:
- accepts "me", but not accepting "meo" or "not me" anymore
- also allow "@mentions" on !commands like !add, !doubleping, etc. just like how it is handled in @ultra pings
- allow special characters as part of name (which will be sanitized later) to allow showing for emotions like "me!!!"
- allow failed mentions (plain text @mentions) for accepted names
- sanitize any special characters appeared in the middle of names, and all subsequent characters
- may allow multiple names in the future...

