### PR TITLE
.replit and replit.nix hidden files

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,108 @@
+# The command that runs the program. If the interpreter field is set, it will have priority and this run command will do nothing
+run = "python3 main.py"
+
+# The primary language of the repl. There can be others, though!
+language = "python3"
+entrypoint = "main.py"
+# A list of globs that specify which files and directories should
+# be hidden in the workspace.
+hidden = ["venv", ".config", "**/__pycache__", "**/.mypy_cache", "**/*.pyc"]
+
+# Specifies which nix channel to use when building the environment.
+[nix]
+channel = "stable-22_11"
+
+# The command to start the interpreter.
+[interpreter]
+  [interpreter.command]
+  args = [
+    "stderred",
+    "--",
+    "prybar-python310",
+    "-q",
+    "--ps1",
+    "\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ",
+    "-i",
+  ]
+  env = { LD_LIBRARY_PATH = "$PYTHON_LD_LIBRARY_PATH" }
+
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH = "$PYTHONHOME/lib/python3.10:${VIRTUAL_ENV}/lib/python3.10/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY = "https://package-proxy.replit.com/pypi/"
+MPLBACKEND = "TkAgg"
+POETRY_CACHE_DIR = "${HOME}/${REPL_SLUG}/.cache/pypoetry"
+
+# Enable unit tests. This is only supported for a few languages.
+[unitTest]
+language = "python3"
+
+# Add a debugger!
+[debugger]
+support = true
+
+  # How to start the debugger.
+  [debugger.interactive]
+  transport = "localhost:0"
+  startCommand = ["dap-python", "main.py"]
+
+    # How to communicate with the debugger.
+    [debugger.interactive.integratedAdapter]
+    dapTcpAddress = "localhost:0"
+
+    # How to tell the debugger to start a debugging session.
+    [debugger.interactive.initializeMessage]
+    command = "initialize"
+    type = "request"
+
+      [debugger.interactive.initializeMessage.arguments]
+      adapterID = "debugpy"
+      clientID = "replit"
+      clientName = "replit.com"
+      columnsStartAt1 = true
+      linesStartAt1 = true
+      locale = "en-us"
+      pathFormat = "path"
+      supportsInvalidatedEvent = true
+      supportsProgressReporting = true
+      supportsRunInTerminalRequest = true
+      supportsVariablePaging = true
+      supportsVariableType = true
+
+    # How to tell the debugger to start the debuggee application.
+    [debugger.interactive.launchMessage]
+    command = "attach"
+    type = "request"
+
+      [debugger.interactive.launchMessage.arguments]
+      logging = {}
+
+# Configures the packager.
+[packager]
+language = "python3"
+ignoredPackages = ["unit_tests"]
+
+  [packager.features]
+  enabledForHosting = false
+  # Enable searching packages from the sidebar.
+  packageSearch = true
+  # Enable guessing what packages are needed from the code.
+  guessImports = true
+
+# These are the files that need to be preserved when this 
+# language template is used as the base language template
+# for Python repos imported from GitHub
+[gitHubImport]
+requiredFiles = [".replit", "replit.nix", ".config", "venv"]
+
+[languages]
+
+[languages.python3]
+pattern = "**/*.py"
+
+[languages.python3.languageServer]
+start = "pylsp"
+
+[deployment]
+run = ["sh", "-c", "python3 main.py"]

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,23 @@
+{ pkgs }: {
+  deps = [
+    pkgs.python310Full
+    pkgs.replitPackages.prybar-python310
+    pkgs.replitPackages.stderred
+  ];
+  env = {
+    PYTHON_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+      # Needed for pandas / numpy
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+      # Needed for pygame
+      pkgs.glib
+      # Needed for matplotlib
+      pkgs.xorg.libX11
+    ];
+    PYTHONHOME = "${pkgs.python310Full}";
+    PYTHONBIN = "${pkgs.python310Full}/bin/python3.10";
+    LANG = "en_US.UTF-8";
+    STDERREDBIN = "${pkgs.replitPackages.stderred}/bin/stderred";
+    PRYBAR_PYTHON_BIN = "${pkgs.replitPackages.prybar-python310}/bin/prybar-python310";
+  };
+}


### PR DESCRIPTION
.replit and replit.nix have gone missing after server migration, these files are copied over from standard python replit for use

the files that we are committing are from the working replit after Traf's fix, so they are from the right version and are working

of course, the missing of these files may not be the only reason that replit was dysfunctional, as the problem was solved by Traf