### PR TITLE
check_history function added

### DIFF
--- a/klee/helpers.py
+++ b/klee/helpers.py
@@ -221,3 +221,32 @@ async def checkHistory(client):
   except Exception as err:
     log(f'ERROR in checkHistory(): {err}')
     handleError(err)
+
+#########################################################################
+
+"""
+def word_checker(wordlist):
+    def check_string(string):
+        for word in wordlist:
+            if word in string:
+                return True
+        return False
+    return check_string
+
+# Example usage
+my_wordlist = ['apple', 'banana', 'orange']
+checker = word_checker(my_wordlist)
+
+print(checker('I love apples'))  # True
+print(checker('I have a pear'))  # False
+
+checker = word_checker(['.u'])
+checker(message)
+
+def word_checker(wordlist):
+    def check_string(message):
+        #initialization
+        member_id = members.UNKNOWN
+        if is 
+    return check_string
+"""

--- a/klee/kommands.py
+++ b/klee/kommands.py
@@ -1,5 +1,5 @@
 from . import const, members, helpers
-from .helpers import is_any_word_in_string, utcTimestamp
+from .helpers import is_any_word_in_string, utcTimestamp, add_slime
 from .logging import log, handleError
 from .stats import AGE_members, zoom_member, zoom_time
 
@@ -308,4 +308,91 @@ async def slimeseason(ctx):
     
   except Exception as err:
     log(f'ERROR in total(): {err}')
+    raise err
+
+#########################################################################
+
+async def shorthand_ping(ctx, username):
+  try:
+    if ctx.channel.id in const.BOT_CHANNELS:  #make sure tempremove could only be executed from certain channels
+      channel = ctx.channel
+      member_id = members.UNKNOWN
+      
+      member = username.strip()
+      member_id = members.id_search(ctx.message, member)
+
+      if member_id == members.UNKNOWN:
+        reply_msg = ('Uh, Klee does not know this name, and therefore cannot tempremove this person... (๑•̆ ૩•̆)')
+      else:
+        member_mention = f'<@{member_id}>'
+        try:
+          helpers.add_slime(member_id, 1)
+          reply_msg = f'{const.MENTION_SLIMEPINGTEST_ROLE} {member_mention} Woah! It is a slime!  (ﾉ>ω<)ﾉ  Klee has counted {AGE_members[member_id]} slimes for {members.get_name(member_id)}!'
+        except KeyError:
+          reply_msg = f'{const.MENTION_SLIMEPINGTEST_ROLE} {member_mention} Klee has added the slime on {utcTimestamp()}.  ( ๑>ᴗ<๑ )  Please private message maple to have this member added.'
+
+      await ctx.message.reply(reply_msg, mention_author=False)
+
+      
+  except Exception as err:
+    log(f'ERROR in total(): {err}')
+    raise err
+
+#########################################################################
+
+#add in number 
+async def ban(ctx, username, client):
+  try:
+    if ctx.channel.id in const.BOT_CHANNELS:  #make sure tempremove could only be executed from certain channels
+      
+      channel = client.get_channel(const.MAIN_CHANNEL)
+      
+      username = username.strip()
+      member_id = members.id_search(ctx.message, username)
+      if member_id == members.UNKNOWN:
+        await ctx.send('Uh, Klee does not know this name, and therefore cannot tempremove this person... (๑•̆ ૩•̆)')
+        return
+
+      # Get the member object from the member ID
+      member = ctx.guild.get_member(member_id)
+      # Get the existing channel permissions
+      overwrites = channel.overwrites
+      # Create or modify the permission overwrite for the member
+      overwrites[member] = discord.PermissionOverwrite(view_channel=False)
+      log(f'{member_id},{member}')
+      # Apply the updated channel permissions
+      await channel.edit(overwrites=overwrites)
+      log('passed3')
+
+      await ctx.send(f"The view_channel permission for {member.name} has been removed.")
+  except Exception as err:
+    log(f'ERROR in ban(): {err}')
+    raise err
+
+
+
+async def unban(ctx, username, client):
+  try:
+    if ctx.channel.id in const.BOT_CHANNELS:  #make sure tempremove could only be executed from certain channels
+      channel = client.get_channel(const.CID_SLIMEPING_CHANNEL)
+
+      username = username.strip()
+      member_id = members.id_search(ctx.message, username)
+
+      if member_id == members.UNKNOWN:
+        await ctx.send('Uh, Klee does not know this name, and therefore cannot tempremove this person... (๑•̆ ૩•̆)')
+        return
+
+      # Get the member object from the member ID
+      member = ctx.guild.get_member(member_id)
+      # Get the existing channel permissions
+      overwrites = channel.overwrites
+      # Create or modify the permission overwrite for the member
+      overwrites[member] = discord.PermissionOverwrite(view_channel=True)
+      # Apply the updated channel permissions
+      await channel.edit(overwrites=overwrites)
+
+      await ctx.send(f"The view_channel permission for {member.name} has been restored.")
+  except Exception as err:
+    log(f'ERROR in unban: {err}')
     raise err

--- a/main.py
+++ b/main.py
@@ -88,17 +88,17 @@ async def message(message):
                 return
             
             #using the previously defined function to check whether the phrase
-            # "?u" is in message.content
-            # ?u = MENTION_ULTRA_ROLE
-
-            if is_any_word_in_string(['?u'], message.content):
+            if is_any_word_in_string(['.u'], message.content):
 
                 member_id = members.UNKNOWN
 
-                # Accepts message in the form '?u user', or 'user ?u'; where 'user' can also be in the form of 'me', or @mention
+                # Accepts message in the form '.u user', or 'user .u'; where 'user' can also be in the form of 'me', or @mention
                 words = message.content.split()
-                if len(words) > 1:
-                    name_part = words[1] if is_any_word_in_string(['?u'], words[0]) else words[0]
+                if len(words) == 1:
+                  member_id = members.id_search(message, "me")
+                  
+                elif len(words) > 1:
+                    name_part = words[1] if is_any_word_in_string(['.u'], words[0]) else words[0]
                     #log(f'{name_part}')
                     member_id = members.id_search(message, name_part)
                 
@@ -151,6 +151,14 @@ async def message(message):
 ######################################################
 # BOT COMMANDS #
 ######################################################
+#test function for banning by per-member denies
+@client.command()
+async def ban(ctx, username):
+  await kommands.ban(ctx, username, client)
+
+@client.command()
+async def unban(ctx, username):
+  await kommands.unban(ctx, username, client)
 
 #method name doubleping, simply wrapper for minus_slime
 @client.command()
@@ -183,6 +191,11 @@ ex.) !slimeadd 5 john doe
 number parameter will be "5" and the *username parameter 
 will be a tuple containing the strings "john" and "doe"
 """
+
+@client.command(aliases=['u'])
+async def shorthand_ping(ctx, username='me'):
+  await kommands.shorthand_ping(ctx, username)
+
 #for the specified member, add 1 zoom and store the time this zoom was reported
 @client.command()
 async def zoom(ctx, member='me'):


### PR DESCRIPTION
Changes:
(1) Add checkHistory on bot start up;
(2) Reply to original message on slime pings and other klee kommands;
(3) Add single letter slime ping ("!u" and ".u");
(4) Add initial ban/unban command (WIP)
---
On checkHistory:
To take care of disconnectivity, the function will process the slime ping channel history within the disconnected time range, and for every PING_MENTIONS, it will call the slimeadd function to account for those slimes.
